### PR TITLE
DOC: example demo_parasite_axes2.py broken on 2.1.0

### DIFF
--- a/examples/axisartist/demo_parasite_axes2.py
+++ b/examples/axisartist/demo_parasite_axes2.py
@@ -28,6 +28,7 @@ par2.axis["right"] = new_fixed_axis(loc="right",
                                     axes=par2,
                                     offset=(offset, 0))
 
+par1.axis["right"].toggle(all=True)
 par2.axis["right"].toggle(all=True)
 
 host.set_xlim(0, 2)


### PR DESCRIPTION
broken in the same way as [#6836](https://github.com/matplotlib/matplotlib/issues/6836)

adding toggle to axis par1 fixes it.

was ok on 2.0.2, but with a fresh install with 2.1.0 it was broken.
